### PR TITLE
修正“插件支持等级”为社区支持

### DIFF
--- a/MikuMikuRig/__init__.py
+++ b/MikuMikuRig/__init__.py
@@ -1,8 +1,9 @@
+# 字典条目说明 https://wiki.blender.org/wiki/Process/Addons/Guidelines/metainfo
 bl_info = {
     "name": "MikuMikuRig", #插件名字
     "author": "William", #作者名字
     "version": (0, 3, 8,5), #插件版本
-    "blender": (2, 92, 0), #blender版本
+    "blender": (2, 92, 0), #需要的*最低* blender 版本
     "location": "3DView > Tools", #插件所在位置
     "description": "自动为MMD模型生成rigify控制器", #描述
     #"warning": "不稳定", #警告

--- a/MikuMikuRig/__init__.py
+++ b/MikuMikuRig/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "location": "3DView > Tools", #插件所在位置
     "description": "自动为MMD模型生成rigify控制器", #描述
     #"warning": "不稳定", #警告
-    "support": 'OFFICIAL', #支持??
+    "support": 'COMMUNITY', #支持等级（社区支持）
     "category": "Rigging", #分类
 }
 import bpy


### PR DESCRIPTION
`OFFICIAL` 代表是blender官方支持的插件。其他的插件一般默认为社区支持。

顺带加了点其他的条目说明