### PR TITLE
修复vmd导入导出, 以及其他若干优化

### DIFF
--- a/MikuMikuRig/__init__.py
+++ b/MikuMikuRig/__init__.py
@@ -1,13 +1,13 @@
 bl_info = {
     "name": "MikuMikuRig", #插件名字
     "author": "William", #作者名字
-    "version": (0, 5, 6, 0), #插件版本
+    "version": (0, 6, 0, 0), #插件版本
     "blender": (2, 90, 0), #需要的*最低* blender 版本
     "location": "3DView > Tools", #插件所在位置
     "description": "快速为各种人形模型生成rigify控制器,一键套mixamo动作", #描述
     "support": 'COMMUNITY', #支持等级（社区支持）
     "category": "Rigging", #分类
-    #"warning": "暂不支持Blender3.0及以上版本",
+    #"warning": "暂不支持Blender4.0及以上版本,3.0以上版本需要替换Rigify修复补丁",
 }
 import bpy
 import bpy_extras
@@ -33,10 +33,6 @@ class MMR_property(bpy.types.PropertyGroup):
     solid_rig:BoolProperty(default=False,description="实心控制器")
     pole_target:BoolProperty(default=False,description="极向目标")
     min_ik_loop:IntProperty(default=10,description="最小IK迭代次数",min=1)
-    lock_location:BoolProperty(default=False,description="锁定动画位置")
-    fade_in_out:IntProperty(default=0,description="淡入淡出长度",min=0)
-    action_scale:FloatProperty(default=1,description="动作缩放",min=0)
-    auto_action_scale:BoolProperty(default=True,description="自动动作缩放")
     subdivide:IntProperty(default=0,description="细分级别",min=0,max=5)
     auto_select_mesh:BoolProperty(default=True,description="自动选择模型")
     auto_select_rigid_body:BoolProperty(default=True,description="自动选择刚体")
@@ -77,13 +73,7 @@ class MMR_property(bpy.types.PropertyGroup):
     quick_assign_index:IntProperty(default=1,description="快速指定序号",min=1)
     quick_assign_mod:BoolProperty(default=False,description="快速指定模式")
     extra_options1:bpy.props.BoolProperty(default=False,description="高级选项")
-    extra_options2:bpy.props.BoolProperty(default=False,description="高级选项")
     mass_multiply_rate:FloatProperty(default=12.5,description="刚体质量倍率",min=0)
-    import_as_NLA_strip: bpy.props.BoolProperty(
-        name='Import as NLA strip',
-        description="Import as NLA strip",
-        default=True
-    )
 
 class Mmr_Panel_Base(bpy.types.Panel):
     bl_space_type = 'VIEW_3D'

--- a/MikuMikuRig/mmr_operators/preset.py
+++ b/MikuMikuRig/mmr_operators/preset.py
@@ -3,8 +3,6 @@ import bpy
 import os
 import json
 from . import rig
-from bpy.props import BoolProperty,IntProperty,FloatProperty,EnumProperty,StringProperty
-
 
 #骨骼枚举属性部分
 
@@ -78,43 +76,21 @@ bone_translate_dict_C={
 built_in_rig_dict_list=['None','MMD_JP','MMD_EN','VRoid']
 built_in_retarget_dict_list=['None','mixamo','Rigify','FBX动捕','BVH动捕']
 
-#mmr骨骼属性类
-class MMR_bone(bpy.types.PropertyGroup):
-    bone_type:StringProperty(description=('Choose the bone type you want to use'))
-    invert:BoolProperty(default=False)
-    mass:FloatProperty(default=0,description="bone mass",min=0)
-
-#注册mmr骨骼属性
-bpy.utils.register_class(MMR_bone)
-bpy.types.PoseBone.mmr_bone = bpy.props.PointerProperty(type=MMR_bone)
-'''
-#定义骨骼头尾是否反转
-bpy.types.PoseBone.mmr_bone_invert=BoolProperty(
+bpy.types.PoseBone.mmr_bone_invert=bpy.props.BoolProperty(
     default=False
 )
 
-bpy.types.PoseBone.mmr_bone_type=bpy.props.EnumProperty(
+'''bpy.types.PoseBone.mmr_bone_type=bpy.props.EnumProperty(
         items=[
             (name, name, '') for name in bone_type_list
         ],
         description=('Choose the bone type2 you want to use'),
-    )
-
-#定义骨骼类型
+    )'''
 #预设属性改为字符串
-bpy.types.PoseBone.mmr_bone_type=StringProperty(
+bpy.types.PoseBone.mmr_bone_type=bpy.props.StringProperty(
         description=('Choose the bone type2 you want to use'),
     )
 
-#定义骨骼质量
-bpy.types.PoseBone.mmr_bone_mass=FloatProperty(
-    default=1,
-    description="bone mass"
-    ,min=0
-    )
-'''
-mmr_bone_property_list=[name for name in MMR_bone.__annotations__.keys()]
-mmr_bone_property_set=set(mmr_bone_property_list)
 #骨架枚举属性部分
 
 my_dir = os.path.dirname(os.path.realpath(__file__))
@@ -131,14 +107,10 @@ preset_dict_dict={
 
 
 def get_preset(pose):
-    preset={
-        'interpretation':mmr_bone_property_list,
-    }
-    data={}
+    preset={}
     for bone in pose.bones:
-        value_list=[value for prop_name,value in bone.mmr_bone.items()]
-        if value_list[0]:
-            data[bone.name]=value_list
+        if bone.mmr_bone_type!='':
+            preset[bone.name]=(bone.mmr_bone_type,bone.mmr_bone_invert)
     return(preset)
 
 def set_bone_type(pose,preset):
@@ -609,14 +581,6 @@ class MMR_Retarget_Panel(Mmr_Panel_Base):
         layout.operator("mmr.import_mixamo",text="Import FBX/BVH")
         layout.operator("mmr.import_vmd",text="Import VMD")
         layout.operator("mmr.export_vmd",text="Bake and export VMD animation")
-        layout.prop(mmr_property, "extra_options2", toggle=True,text='Extra Options')
-        if mmr_property.extra_options2:
-            layout.prop(mmr_property,'fade_in_out',text="Fade in out")
-            layout.prop(mmr_property,'auto_action_scale',text="Auto animation scale")
-            if mmr_property.auto_action_scale==False:
-                layout.prop(mmr_property,'action_scale',text="Animation scale")
-            layout.prop(mmr_property,'lock_location',text="Lock animation location")
-            layout.prop(mmr_property,'import_as_NLA_strip',text="Import as NLA strip")
 Class_list=[
     MMR_Bone_Panel,MMR_Arm_Panel,OT_Add_Preset,OT_Delete_Preset,OT_Read_Preset,OT_Overwrite_Preset,OT_Rig_Preset,
     OT_QA_Start,OT_QA_End,OT_QA_Assign,OT_QA_Assign_Invert,OT_QA_Skip,MMR_Retarget_Panel,


### PR DESCRIPTION
mmd_tools的一些更新导致mmr插件的vmd导入导出不再工作, 我进行了修复.
可以直接安装的压缩包在下面链接里.

Some updates to mmd_tools caused the mmr plugin's vmd import and export to no longer work, I fixed that.
The zip file that can be installed directly is in the link below.

https://github.com/mijuku233/Miku_Miku_Rig/releases/tag/0.6.0